### PR TITLE
Fix nav highlighting and limit background light to home section

### DIFF
--- a/css/Styleback.css
+++ b/css/Styleback.css
@@ -27,9 +27,9 @@
     height: 8px;
     background: radial-gradient(circle, #00c39c, transparent);
     border-radius: 50%;
-    opacity: 0.6;
+    opacity: 0.4;
     animation: float 12s ease-in-out infinite;
-    box-shadow: 0 0 20px #007a62;
+    box-shadow: 0 0 10px #007a62;
     /* Menggunakan persentase untuk posisi agar responsif */
     transform-origin: center center;
     will-change: transform; /* Optimasi performa animasi */
@@ -39,8 +39,8 @@
 .light-effect {
     position: absolute;
     border-radius: 50%;
-    background: radial-gradient(circle, rgba(0, 93, 160, 0.3), transparent);
-    filter: blur(60px);
+    background: radial-gradient(circle, rgba(0, 93, 160, 0.15), transparent);
+    filter: blur(30px);
     animation: pulse 6s ease-in-out infinite;
     pointer-events: none;
     z-index: 2;

--- a/js/script.js
+++ b/js/script.js
@@ -23,7 +23,7 @@ window.onscroll = () => {
 
             navLinks.forEach(links => {
                 links.classList.remove('active');
-                document.querySelector('header nav a[href*=' + id + '] ').classList.add('active');
+                document.querySelector('header nav a[href*=' + id + ']').classList.add('active');
             });
             sec.classList.add('show-animate');
         }

--- a/js/scriptback.js
+++ b/js/scriptback.js
@@ -23,7 +23,7 @@ class ParticleSystem {
     
     createParticles() {
         this.particles = [];
-        const particleCount = Math.floor((this.canvas.width * this.canvas.height) / 12000);
+        const particleCount = Math.floor((this.canvas.width * this.canvas.height) / 24000);
         
         for (let i = 0; i < particleCount; i++) {
             this.particles.push({
@@ -83,7 +83,7 @@ class ParticleSystem {
         
         // Draw glow effect
         this.ctx.save();
-        this.ctx.globalAlpha = particle.opacity * pulse * 0.6;
+        this.ctx.globalAlpha = particle.opacity * pulse * 0.4;
         
         const glowGradient = this.ctx.createRadialGradient(
             particle.x, particle.y, 0,

--- a/js/section-effects.js
+++ b/js/section-effects.js
@@ -1,5 +1,12 @@
 // Script untuk menerapkan efek canvas, floating-elements, dan light-effect di berbagai section
 document.addEventListener('DOMContentLoaded', function() {
+    // Hapus light-effect dari section selain home jika ada
+    document.querySelectorAll('section .light-effect').forEach(effect => {
+        if (!effect.closest('#home')) {
+            effect.remove();
+        }
+    });
+
     // Fungsi untuk membuat elemen canvas
     function createParticleCanvas(sectionId) {
         const section = document.getElementById(sectionId);
@@ -292,8 +299,8 @@ document.addEventListener('DOMContentLoaded', function() {
             createFloatingElements(sectionId);
         }
         
-        // Skip pembuatan light-effects untuk home section karena sudah ada
-        if (sectionId !== 'home' || !document.querySelector('.home .light-effect')) {
+        // Tambahkan light-effect hanya pada section home
+        if (sectionId === 'home' && !document.querySelector('.home .light-effect')) {
             createLightEffects(sectionId);
         }
         


### PR DESCRIPTION
## Summary
- remove stray space in nav link querySelector to avoid invalid selector and enable active link highlighting
- lighten background visuals by lowering floating element opacity, blur, and particle count for smoother performance
- ensure light effects appear only on the home section and strip them from other sections

## Testing
- `node --check js/section-effects.js`
- `node --check js/script.js`
- `node --check js/scriptback.js`
- `npx --yes prettier --check js/section-effects.js js/script.js js/scriptback.js css/Styleback.css` *(warn: code style issues found in 4 files)*

------
https://chatgpt.com/codex/tasks/task_e_68abb964d1ec832eb92e81a23489f4a2